### PR TITLE
bugfix/OAR-52 - Error 500 on DiscordID

### DIFF
--- a/bot/exceptions.py
+++ b/bot/exceptions.py
@@ -88,7 +88,11 @@ class DiscordApiException(HelpfulError):
 
     def handle_error_code(self, response):
         try:
-            msg = response.json()['message']
+            json_res = response.json()
+            if 'message' in json_res:
+                msg = json_res['message']
+            else:
+                msg = response.reason
         except JSONDecodeError:
             msg = f'Impossible to format response as JSON.\n{response.text}'
         self.error_code = response.status_code

--- a/bot/models.py
+++ b/bot/models.py
@@ -7,7 +7,7 @@ from bot.utils import discord_api_get, discord_api_patch, discord_api_post
 
 class ApiMixin:
     """
-    This class loads content from `response` into class attributtes.
+    This class loads content from `response` into class attributes.
     """
 
     def __init__(self, url=None, *, response=None):

--- a/registration/forms/forms.py
+++ b/registration/forms/forms.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from smtplib import SMTPException
 
 from crispy_forms.helper import FormHelper
@@ -73,12 +74,17 @@ class SignUpForm(auth_forms.UserCreationForm):
     def clean_discord_id(self):
         data = self.cleaned_data.get('discord_id')
         if data:
+            if re.match(r'.+#\d+', data):
+                msg = _('seems like that\'s your discord discriminator not your identifier.').capitalize()
+                msg += ' ' + _('right click on your user and then click on %(popup_msg)s.').capitalize() % {
+                    'popup_msg': 'Copy ID'
+                }
+                raise ValidationError(msg)
             try:
                 data = User(data)
             except DiscordApiException:
                 msg = _('seems like your user couldn\'t be found, do you have any server in common with our bot?')
-                msg = msg.capitalize()
-                raise ValidationError(msg)
+                raise ValidationError(msg.capitalize())
 
         return data
 

--- a/tests/registration/test_forms.py
+++ b/tests/registration/test_forms.py
@@ -82,6 +82,13 @@ class TestSignUpForm(TestCase):
             form = forms.SignUpForm(self.request, data=data)
             self.assertTrue(form.is_valid())
 
+    def test_discord_id_is_discriminator_ko(self):
+        data = self.data_ok.copy()
+        data['discord_id'] = f'{fake.user_name()}#1234'
+        form = forms.SignUpForm(self.request, data=data)
+
+        self.assertFalse(form.is_valid())
+
     def test_form_wrong_confirm_password_ko(self):
         data_ko = self.data_ok.copy()
         data_ko['password2'] = fake.word()

--- a/tests/registration/test_views.py
+++ b/tests/registration/test_views.py
@@ -219,6 +219,15 @@ class TestSignUpView(TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 302, 'User is not redirected.')
 
+    def test_discord_id_is_discriminator_ko(self):
+        data_with_wrong_discord_id = self.data_ok.copy()
+        data_with_wrong_discord_id['discord_id'] = f'{fake.user_name()}#1234'
+        response = self.client.post(self.url, data=data_with_wrong_discord_id)
+        expected_error = 'Seems like that\'s your discord discriminator not your identifier.' + \
+            ' Right click on your user and then click on Copy ID.'
+
+        self.assertFormError(response, 'form', 'discord_id', expected_error)
+
 
 class TestActivateAccountView(TestCase):
     """


### PR DESCRIPTION
# Resume

There was an issue with Discord API response and given user that it's not an ID. Now it takes a regex and if it matches it tells the user what to do.