### PR TITLE
feature/OAR-63 -  Error on launching gunicorn

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,3 @@
-# NPM & React
-API_DOMAIN=oilandrope-project.com
-WEBSOCKET_DOMAIN=live.oilandrope-project.com
-
 # Django
 DJANGO_SETTINGS_MODULE=oilandrope.settings
 DEBUG=False

--- a/oilandrope/asgi.py
+++ b/oilandrope/asgi.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
 from django.core.asgi import get_asgi_application
 from django.urls import re_path
 
@@ -17,9 +18,11 @@ from chat.consumers import ChatConsumer  # noqa: E402
 
 application = ProtocolTypeRouter({
     'http': django_asgi_app,
-    'websocket': AuthMiddlewareStack(
-        URLRouter([
-            re_path(r'^ws/chat/$', ChatConsumer.as_asgi(), name='connect',),
-        ]),
+    'websocket': AllowedHostsOriginValidator(
+        AuthMiddlewareStack(
+            URLRouter([
+                re_path(r'^ws/chat/$', ChatConsumer.as_asgi(), name='connect',),
+            ]),
+        ),
     ),
 })

--- a/oilandrope/urls.py
+++ b/oilandrope/urls.py
@@ -14,7 +14,6 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-import debug_toolbar
 from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
@@ -52,5 +51,6 @@ urlpatterns += i18n_patterns(
 )
 
 if settings.DEBUG:  # pragma: no cover
+    import debug_toolbar
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     urlpatterns.insert(0, path('__debug__/', include(debug_toolbar.urls)))


### PR DESCRIPTION
# Resume

Fixed error on importing `debug_toolbar` for non development
environments so added under if statement.
Also removed old `.env.example` variables.

**BREAKING CHANGE**: Added security by `ALLOWED_HOST` on WebSockets.