### PR TITLE
feature/OAR-68 -  Add Bot to API

### DIFF
--- a/api/routers/registration.py
+++ b/api/routers/registration.py
@@ -1,8 +1,9 @@
-from ..viewsets.registration import ProfileViewSet, UserViewSet
+from ..viewsets.registration import BotViewSet, ProfileViewSet, UserViewSet
 from .routers import OilAndRopeDefaultRouter
 
 router = OilAndRopeDefaultRouter()
 router.register(prefix=r'user', viewset=UserViewSet, basename='user')
 router.register(prefix=r'profile', viewset=ProfileViewSet, basename='profile')
+router.register(prefix=r'bot', viewset=BotViewSet, basename='bot')
 
 urls = router.urls

--- a/api/serializers/registration.py
+++ b/api/serializers/registration.py
@@ -1,4 +1,5 @@
 from django.apps import apps
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
@@ -56,4 +57,26 @@ class SimpleUserSerializer(serializers.ModelSerializer):
         model = User
         fields = (
             'id', 'username', 'first_name', 'last_name', 'email',
+        )
+
+
+class BotSerializer(serializers.ModelSerializer):
+    """
+    API serializer for Oil & Rope bot.
+    This serializer is quite simple and just includes: `id`, `username`, `email`, `command_prefix` and `description`.
+    """
+
+    command_prefix = serializers.SerializerMethodField(method_name='get_command_prefix')
+    description = serializers.SerializerMethodField(method_name='get_description')
+
+    def get_command_prefix(self, obj):
+        return settings.BOT_COMMAND_PREFIX
+
+    def get_description(self, obj):
+        return settings.BOT_DESCRIPTION
+
+    class Meta:
+        model = User
+        fields = (
+            'id', 'username', 'email', 'command_prefix', 'description',
         )

--- a/api/viewsets/registration.py
+++ b/api/viewsets/registration.py
@@ -1,13 +1,15 @@
 from django.apps import apps
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from rest_framework import viewsets
-from rest_framework.permissions import IsAdminUser
+from rest_framework.permissions import IsAdminUser, IsAuthenticated
+from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
 from common.constants import models
 
 from ..permissions.registration import IsUserOrAdmin, IsUserProfileOrAdmin
-from ..serializers.registration import ProfileSerializer, UserSerializer
+from ..serializers.registration import BotSerializer, ProfileSerializer, UserSerializer
 
 Profile = apps.get_model(models.PROFILE_MODEL)
 User = get_user_model()
@@ -51,3 +53,17 @@ class ProfileViewSet(viewsets.ReadOnlyModelViewSet):
         if self.kwargs[self.lookup_url_kwarg or self.lookup_field] == '@me':
             return self.request.user.profile
         return super().get_object()
+
+
+class BotViewSet(viewsets.ViewSet):
+    """
+    ViewSet for Oil & Rope Bot.
+    """
+
+    permission_classes = [IsAuthenticated]
+    serializer_class = BotSerializer
+
+    def list(self, request):
+        bot = User.objects.get(email=settings.DEFAULT_FROM_EMAIL)
+        serializer = BotSerializer(bot)
+        return Response(data=serializer.data)

--- a/tests/api/serializers/test_registration_serializers.py
+++ b/tests/api/serializers/test_registration_serializers.py
@@ -1,13 +1,12 @@
 from django.apps import apps
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase
-from faker import Faker
 from model_bakery import baker
 
-from api.serializers.registration import ProfileSerializer, UserSerializer
+from api.serializers.registration import BotSerializer, ProfileSerializer, UserSerializer
 from common.constants import models
-
-fake = Faker()
+from tests import fake
 
 User = get_user_model()
 Profile = apps.get_model(models.PROFILE_MODEL)
@@ -64,3 +63,23 @@ class TestProfileSerializer(TestCase):
         serialized_result = serialized_obj.data
 
         self.assertEqual(expected_bio, serialized_result['bio'])
+
+
+class TestBotSerializer(TestCase):
+    serializer_class = BotSerializer
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.bot = User.objects.get(email=settings.DEFAULT_FROM_EMAIL)
+
+    def test_command_prefix_ok(self):
+        serialized_obj = self.serializer_class(self.bot)
+        serialized_result = serialized_obj.data
+
+        self.assertEqual(settings.BOT_COMMAND_PREFIX, serialized_result['command_prefix'])
+
+    def test_description_ok(self):
+        serialized_obj = self.serializer_class(self.bot)
+        serialized_result = serialized_obj.data
+
+        self.assertEqual(settings.BOT_DESCRIPTION, serialized_result['description'])

--- a/tests/api/viewsets/test_registration_viewsets.py
+++ b/tests/api/viewsets/test_registration_viewsets.py
@@ -175,6 +175,5 @@ class TestBotViewSet(TestCase):
     def test_authenticated_access_bot_description_ok(self):
         self.client.force_login(self.bot)
         response = self.client.get(self.url)
-        breakpoint()
 
         self.assertEqual(settings.BOT_DESCRIPTION, response.data['description'])


### PR DESCRIPTION
# Resume

Since [Tabletop]() needs access to Bot information a view has been created.
This view is intended to be accessed only authenticated users. 