### PR TITLE
feature/OAR-79 - Wrong link on registration email

### DIFF
--- a/common/context_processors/utils.py
+++ b/common/context_processors/utils.py
@@ -1,12 +1,15 @@
-def requests_utils(request):
+from django.http.request import HttpRequest
+
+
+def requests_utils(request: HttpRequest):
+    scheme = request.scheme or 'https'
     host = request.get_host()
     port = request.get_port()
-    uri = '{}'.format(host)
-    current_uri = request.build_absolute_uri()
-    uri = 'https://{}'.format(uri) if request.is_secure() else 'http://{}'.format(uri)
+    uri = request.build_absolute_uri()
+
     return {
+        'scheme': scheme,
         'host': host,
         'port': port,
         'uri': uri,
-        'current_uri': current_uri,
     }

--- a/common/utils/auth.py
+++ b/common/utils/auth.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING
+
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 
+if TYPE_CHECKING:
+    from registration.models import User
 
-def generate_token(user) -> str:
+
+def generate_token(user: 'User') -> str:
     """
     Generates a token associated with a user.
 

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,11 +1,12 @@
 from django.conf import settings
+from django.http.request import HttpRequest
 from django.utils.translation import get_language_from_request
 
 from common.enums import AvailableIcons, JavaScriptActions
 from registration.models import Profile
 
 
-def language(request):
+def language(request: HttpRequest):
     """
     Sets language depending on the profile.
     """
@@ -32,7 +33,7 @@ def language(request):
     return content
 
 
-def handy_settings(request):
+def handy_settings(request: HttpRequest):
     """
     Sets handy settings for the frontend.
 

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,4 +1,8 @@
+from typing import Union
+
 from django.conf import settings
+from django.core.handlers.asgi import ASGIRequest
+from django.core.handlers.wsgi import WSGIRequest
 from django.http.request import HttpRequest
 from django.utils.translation import get_language_from_request
 
@@ -6,7 +10,7 @@ from common.enums import AvailableIcons, JavaScriptActions
 from registration.models import Profile
 
 
-def language(request: HttpRequest):
+def language(request: Union[HttpRequest, WSGIRequest, ASGIRequest]):
     """
     Sets language depending on the profile.
     """

--- a/oar_email/templates/email_templates/confirm_email.html
+++ b/oar_email/templates/email_templates/confirm_email.html
@@ -19,7 +19,7 @@
     </div>
     <div class="row justify-content-center">
       <a
-        href="{{ protocol }}://{{ domain }}{% url 'registration:auth:activate' token object.pk %}"
+        href="{{ scheme }}://{{ host }}{% url 'registration:auth:activate' token object.pk %}"
         class="btn btn-primary col-11 col-md-6 col-lg-4 col-xl-2"
       >
         {% translate "activate account"|capfirst %}
@@ -31,7 +31,7 @@
           {% translate "if you can't click on the link here's raw"|capfirst %}
           <br />
           <code>
-            {{ protocol }}://{{ domain }}{% url 'registration:auth:activate' token object.pk %}
+            {{ scheme }}://{{ host }}{% url 'registration:auth:activate' token object.pk %}
           </code>
         </small>
       </div>

--- a/oar_email/utils.py
+++ b/oar_email/utils.py
@@ -1,0 +1,32 @@
+from typing import TYPE_CHECKING
+
+from django.core.mail import send_mail
+from django.http.request import HttpRequest
+from django.template.loader import render_to_string
+from django.utils.translation import gettext_lazy as _
+
+from common.context_processors.utils import requests_utils
+from common.templatetags.string_utils import capfirstletter as cfl
+from common.utils.auth import generate_token
+
+if TYPE_CHECKING:
+    from registration.models import User
+
+
+def send_confirmation_email(request: HttpRequest, user: 'User', template: str = 'email_templates/confirm_email.html'):
+    """
+    Sends an standard Email Confirmation mail.
+    """
+
+    context = {
+        'token': generate_token(user),
+        'object': user,
+    }
+    context.update(requests_utils(request))
+    html_msg = render_to_string(template, context, request)
+
+    subject = _('welcome to %(title)s!') % {'title': 'Oil & Rope'}
+    send_mail(
+        subject=cfl(subject), message='', from_email=None,
+        recipient_list=[user.email], html_message=html_msg,
+    )

--- a/oar_email/views.py
+++ b/oar_email/views.py
@@ -13,11 +13,11 @@ class EmailView(LoginRequiredMixin, TemplateView):
     """
 
     def dispatch(self, request, *args, **kwargs):
-        if not settings.DEBUG:
-            raise PermissionDenied
         if not request.user.is_authenticated:
             return super().dispatch(request, *args, **kwargs)
         if not request.user.is_staff:
+            raise PermissionDenied
+        if not settings.DEBUG:
             raise PermissionDenied
         return super().dispatch(request, *args, **kwargs)
 

--- a/oar_email/views.py
+++ b/oar_email/views.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.views.generic import TemplateView
@@ -12,6 +13,8 @@ class EmailView(LoginRequiredMixin, TemplateView):
     """
 
     def dispatch(self, request, *args, **kwargs):
+        if not settings.DEBUG:
+            raise PermissionDenied
         if not request.user.is_authenticated:
             return super().dispatch(request, *args, **kwargs)
         if not request.user.is_staff:
@@ -32,6 +35,5 @@ class EmailView(LoginRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({'protocol': self.request.scheme, 'domain': self.request.headers.get('Host', 'localhost')})
         context.update(self.parse_context())
         return context

--- a/registration/forms/forms.py
+++ b/registration/forms/forms.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import re
 from smtplib import SMTPException
+from typing import TYPE_CHECKING
 
 from crispy_forms.helper import FormHelper
 from django import forms
@@ -9,19 +10,20 @@ from django.conf import settings
 from django.contrib.auth import forms as auth_forms
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
-from django.core.mail import send_mail
-from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
 from bot.exceptions import DiscordApiException
-from bot.models import User
+from bot.models import User as DiscordUser
 from common.forms.widgets import DateWidget
-from common.utils.auth import generate_token
+from oar_email.utils import send_confirmation_email
 
 from .layout import (LoginFormLayout, PasswordResetFormLayout, ResendEmailFormLayout, SetPasswordFormLayout,
                      SignUpFormLayout, UserFormLayout)
 
 LOGGER = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from registration.models import User
 
 
 class LoginForm(auth_forms.AuthenticationForm):
@@ -84,31 +86,12 @@ class SignUpForm(auth_forms.UserCreationForm):
                 }
                 raise ValidationError(msg)
             try:
-                User(data)
+                DiscordUser(data)
             except DiscordApiException:
                 msg = _('seems like your user couldn\'t be found, do you have any server in common with our bot?')
                 raise ValidationError(msg.capitalize())
 
         return data
-
-    def _send_email_confirmation(self, user):
-        """
-        Sends a confirmation email to the user.
-        """
-
-        html_msg = render_to_string('email_templates/confirm_email.html', {
-            # We declare localhost as default for tests purposes
-            'domain': self.request.META.get('HTTP_HOST', 'http://localhost'),
-            'token': generate_token(user),
-            'object': user
-        })
-
-        title = 'Oil & Rope'
-        subject = _('welcome to %(title)s!') % {'title': title}
-        send_mail(
-            subject=str(subject).capitalize(), message='', from_email=None,
-            recipient_list=[user.email], html_message=html_msg,
-        )
 
     def save(self, commit=True):
         """
@@ -120,14 +103,14 @@ class SignUpForm(auth_forms.UserCreationForm):
             The user created.
         """
 
-        instance = super().save(commit=False)
+        instance: 'User' = super().save(commit=False)
         # Set active to False until user activates email
         instance.is_active = False
         instance.discord_id = self.cleaned_data.get('discord_id', '')
         if commit:
             instance.save()
             try:
-                self._send_email_confirmation(instance)
+                send_confirmation_email(self.request, instance)
             # NOTE: ConnectionError is when SMTP server is unreachable, SMTPException is for credentials, bad format...
             except (ConnectionError, SMTPException) as ex:
                 LOGGER.exception(ex)

--- a/tests/common/context_processors/test_utils.py
+++ b/tests/common/context_processors/test_utils.py
@@ -12,12 +12,12 @@ class TestUtilsContextProcessor(TestCase):
 
     def test_requests_utils(self):
         ctx = requests_utils(self.get_request)
+        scheme = 'http'
         host = 'testserver'
         port = '80'
-        uri = 'http://testserver'
-        current_uri = self.get_request.build_absolute_uri()
+        uri = 'http://testserver/'
 
+        self.assertEqual(ctx['scheme'], scheme)
         self.assertEqual(ctx['host'], host)
         self.assertEqual(ctx['port'], port)
         self.assertEqual(ctx['uri'], uri)
-        self.assertEqual(ctx['current_uri'], current_uri)

--- a/tests/registration/test_forms.py
+++ b/tests/registration/test_forms.py
@@ -63,7 +63,9 @@ class TestSignUpForm(TestCase):
             'password1': password,
             'password2': password,
         }
-        self.request = RequestFactory().get('/')
+
+        request = self.client.get('/').wsgi_request
+        self.request = request
 
     def test_form_ok(self):
         form = forms.SignUpForm(self.request, data=self.data_ok)


### PR DESCRIPTION
# Description

When creating a new user the confirmation mail doesn't have scheme which ends into a weird and non-clickable link.