### PR TITLE
feature/OAR-64 - User can't leave session and Game master can't remove user

### DIFF
--- a/roleplay/templates/roleplay/campaign/include/campaign_sessions.html
+++ b/roleplay/templates/roleplay/campaign/include/campaign_sessions.html
@@ -1,7 +1,8 @@
 {% load i18n %}
 
 <section class="row justify-content-around">
-  {% if object.session_set.exists %}
+
+  {% if campaign.session_set.exists and request.user in campaign.game_masters %}
     <div class="col col-md-8 col-lg-4 col-xl-auto">
       <a
         href="{% url 'roleplay:session:create' campaign.pk %}"
@@ -15,12 +16,12 @@
     </div>
   {% endif %}
   <div class="w-100 my-2"></div>
-  {% for session in object.session_set.all %}
-    {% include 'roleplay/session/include/session_card.html' with session=session only %}
+  {% for session in campaign.session_set.all %}
+    {% include 'roleplay/session/include/session_card.html' with session=session request=request only %}
   {% empty %}
     <div class="col">
-      {% if user in object.game_masters %}
-        {% include 'roleplay/session/include/prepare_first_session_card.html' with campaign=object %}
+      {% if user in campaign.game_masters %}
+        {% include 'roleplay/session/include/prepare_first_session_card.html' with campaign=campaign %}
       {% else %}
         <h5 class="text-center">
           {% translate "no sessions yet."|capfirst %}

--- a/roleplay/templates/roleplay/campaign/include/campaign_settings.html
+++ b/roleplay/templates/roleplay/campaign/include/campaign_settings.html
@@ -214,34 +214,34 @@
   </div>
 </section>
 
-<hr class="text-danger">
-<section class="row justify-content-around px-2">
-  <h3 class="text-center text-danger fw-light mb-4">
-    {% translate "danger zone"|capfirst %}
-  </h3>
-  {% if request.user in campaign.users.all %}
-    <a
-      href="{% url 'roleplay:campaign:leave' campaign.pk %}"
-      class="col mb-3 col-md-4 col-lg-3 btn btn-danger"
-      title="{% translate "leave this campaign"|capfirst %}"
-      data-bs-toggle="tooltip"
-      data-bs-placement="top"
-    >
-      <i class="bi-box-arrow-left"></i>
-      {% translate "leave"|capfirst %}
-    </a>
-  {% endif %}
-  <div class="w-100"></div>
-  {% if request.user == campaign.owner %}
-    <a
-      href="{% url 'roleplay:campaign:delete' campaign.pk %}"
-      class="col col-md-4 col-lg-3 btn btn-danger"
-      title="{% translate "delete this campaign"|capfirst %}"
-      data-bs-toggle="tooltip"
-      data-bs-placement="top"
-    >
-      {{ ICONS.TRASH|safe }}
-      {% translate "delete"|capfirst %}
-    </a>
-  {% endif %}
-</section>
+{% if request.user in campaign.users.all %}
+  <hr class="text-danger">
+  <section class="row justify-content-around px-2">
+    <h3 class="text-center text-danger fw-light mb-4">
+      {% translate "danger zone"|capfirst %}
+    </h3>
+      <a
+        href="{% url 'roleplay:campaign:leave' campaign.pk %}"
+        class="col mb-3 col-md-4 col-lg-3 btn btn-danger"
+        title="{% translate "leave this campaign"|capfirst %}"
+        data-bs-toggle="tooltip"
+        data-bs-placement="top"
+      >
+        <i class="bi-box-arrow-left"></i>
+        {% translate "leave"|capfirst %}
+      </a>
+      <div class="w-100"></div>
+      {% if request.user == campaign.owner %}
+      <a
+        href="{% url 'roleplay:campaign:delete' campaign.pk %}"
+        class="col col-md-4 col-lg-3 btn btn-danger"
+        title="{% translate "delete this campaign"|capfirst %}"
+        data-bs-toggle="tooltip"
+        data-bs-placement="top"
+        >
+        {{ ICONS.TRASH|safe }}
+        {% translate "delete"|capfirst %}
+      </a>
+    {% endif %}
+  </section>
+{% endif %}

--- a/roleplay/templates/roleplay/campaign/include/campaign_settings.html
+++ b/roleplay/templates/roleplay/campaign/include/campaign_settings.html
@@ -183,6 +183,25 @@
         {% endif %}
         <p>
           {{ player.username }}
+          {% if player in campaign.game_masters  %}
+            <i
+              class="bi-brush-fill"
+              title="{% translate "game master"|title %}"
+              data-bs-toggle="tooltip"
+              data-bs-placement="top"
+            ></i>
+          {% endif %}
+          {% if request.user in campaign.game_masters and request.user.pk != player.pk %}
+            <a
+                href="{% url 'roleplay:campaign:remove-player' pk=campaign.pk user_pk=player.pk %}"
+                class="btn btn-sm btn-danger"
+                title="{% translate "remove user"|capfirst %}"
+                data-bs-toggle="tooltip"
+                data-bs-placement="top"
+            >
+              {{ ICONS.TRASH|safe }}
+            </a>
+          {% endif %}
         </p>
       </div>
     {% empty %}
@@ -195,24 +214,34 @@
   </div>
 </section>
 
-{% if request.user == campaign.owner %}
-  <hr class="text-danger">
-  <section class="row justify-content-around">
-    <h3 class="text-center text-danger fw-light">
-      {% translate "danger zone"|capfirst %}
-    </h3>
-    <div class="col">
-      <div class="row justify-content-around mt-1">
-        <div class="col-12 col-md-5 col-lg-4 col-xl-3">
-          <a
-            href="{% url 'roleplay:campaign:delete' campaign.pk %}"
-            class="btn btn-danger w-100"
-          >
-            {{ ICONS.TRASH|safe }}
-            {% translate "delete"|capfirst %}
-          </a>
-        </div>
-      </div>
-    </div>
-  </section>
-{% endif %}
+<hr class="text-danger">
+<section class="row justify-content-around px-2">
+  <h3 class="text-center text-danger fw-light mb-4">
+    {% translate "danger zone"|capfirst %}
+  </h3>
+  {% if request.user in campaign.users.all %}
+    <a
+      href="{% url 'roleplay:campaign:leave' campaign.pk %}"
+      class="col mb-3 col-md-4 col-lg-3 btn btn-danger"
+      title="{% translate "leave this campaign"|capfirst %}"
+      data-bs-toggle="tooltip"
+      data-bs-placement="top"
+    >
+      <i class="bi-box-arrow-left"></i>
+      {% translate "leave"|capfirst %}
+    </a>
+  {% endif %}
+  <div class="w-100"></div>
+  {% if request.user == campaign.owner %}
+    <a
+      href="{% url 'roleplay:campaign:delete' campaign.pk %}"
+      class="col col-md-4 col-lg-3 btn btn-danger"
+      title="{% translate "delete this campaign"|capfirst %}"
+      data-bs-toggle="tooltip"
+      data-bs-placement="top"
+    >
+      {{ ICONS.TRASH|safe }}
+      {% translate "delete"|capfirst %}
+    </a>
+  {% endif %}
+</section>

--- a/roleplay/templates/roleplay/session/include/session_card.html
+++ b/roleplay/templates/roleplay/session/include/session_card.html
@@ -32,15 +32,17 @@
                 <i class="ic ic-quill"></i>
                 {{ session.name }}
               </a>
-              <div class="my-2"></div>
-              <a
-                class="small link-info text-decoration-none"
-                href="{{ TABLETOP_URL }}/campaign/{{ session.campaign.pk }}"
-                target="_blank"
-              >
-                <i class="ic ic-dice"></i>
-                {% translate "start game"|title %}
-              </a>
+              {% if request.user in session.campaign.users.all %}
+                <div class="my-2"></div>
+                <a
+                  class="small link-info text-decoration-none"
+                  href="{{ TABLETOP_URL }}/campaign/{{ session.campaign.pk }}"
+                  target="_blank"
+                >
+                  <i class="ic ic-dice"></i>
+                  {% translate "start game"|title %}
+                </a>
+              {% endif %}
             </h4>
             <small class="text-muted">
               [{{ session.campaign.get_system_display }}]

--- a/roleplay/urls.py
+++ b/roleplay/urls.py
@@ -23,6 +23,7 @@ CAMPAIGN_PATTERNS = [
     path('<int:pk>/', views.CampaignDetailView.as_view(), name='detail'),
     path('create/<int:world_pk>/', views.CampaignCreateView.as_view(), name='create'),
     path('<int:pk>/leave/', views.CampaignLeaveView.as_view(), name='leave'),
+    path('<int:pk>/remove/<int:user_pk>/', views.CampaignRemovePlayerView.as_view(), name='remove-player'),
     path('<int:pk>/<str:token>/', views.CampaignJoinView.as_view(), name='join'),
     path('edit/<int:pk>/', views.CampaignUpdateView.as_view(), name='edit'),
     path('delete/<int:pk>/', views.CampaignDeleteView.as_view(), name='delete'),

--- a/roleplay/urls.py
+++ b/roleplay/urls.py
@@ -22,6 +22,7 @@ CAMPAIGN_PATTERNS = [
     path('@me/', views.CampaignUserListView.as_view(), name='list-private'),
     path('<int:pk>/', views.CampaignDetailView.as_view(), name='detail'),
     path('create/<int:world_pk>/', views.CampaignCreateView.as_view(), name='create'),
+    path('<int:pk>/leave/', views.CampaignLeaveView.as_view(), name='leave'),
     path('<int:pk>/<str:token>/', views.CampaignJoinView.as_view(), name='join'),
     path('edit/<int:pk>/', views.CampaignUpdateView.as_view(), name='edit'),
     path('delete/<int:pk>/', views.CampaignDeleteView.as_view(), name='delete'),

--- a/tests/roleplay/test_views.py
+++ b/tests/roleplay/test_views.py
@@ -1150,10 +1150,10 @@ class TestCampaignDetailView(TestCase):
         cls.world = generate_place(site_type=enums.SiteTypes.WORLD)
 
     def setUp(self):
-        self.private_campaign = baker.make_recipe('roleplay.private_campaign', place=self.world)
+        self.private_campaign: Campaign = baker.make_recipe('roleplay.private_campaign', place=self.world)
         self.private_campaign.users.add(self.user)
         self.private_campaign_url = resolve_url(self.private_campaign)
-        self.public_campaign = baker.make_recipe('roleplay.public_campaign', place=self.world)
+        self.public_campaign: Campaign = baker.make_recipe('roleplay.public_campaign', place=self.world)
         self.public_campaign_url = resolve_url(self.public_campaign)
 
     def test_access_anonymous_ko(self):
@@ -1287,6 +1287,22 @@ class TestCampaignDetailView(TestCase):
         response = self.client.get(self.private_campaign_url)
 
         self.assertContains(response=response, text='Leave')
+
+    def test_player_dont_see_create_session_button_in_campaign_with_sessions_ok(self):
+        baker.make_recipe('roleplay.session', campaign=self.private_campaign)
+        self.client.force_login(self.user)
+        response = self.client.get(self.private_campaign_url)
+
+        self.assertNotContains(response=response, text='Create session')
+
+    def test_game_master_sees_create_session_button_in_campaign_with_sessions_ok(self):
+        baker.make_recipe('roleplay.session', campaign=self.private_campaign)
+        gm = baker.make_recipe('registration.user')
+        self.private_campaign.add_game_masters(gm)
+        self.client.force_login(gm)
+        response = self.client.get(self.private_campaign_url)
+
+        self.assertContains(response=response, text='Create session')
 
 
 class TestCampaignDeleteView(TestCase):

--- a/tests/roleplay/test_views.py
+++ b/tests/roleplay/test_views.py
@@ -796,12 +796,6 @@ class TestCampaignLeaveView(TestCase):
 
         self.assertRedirects(response=response, expected_url=expected_url)
 
-    def test_user_is_removed_from_campaign_ok(self):
-        self.client.force_login(self.user)
-        self.client.get(self.url)
-
-        self.assertNotIn(self.user, self.instance.users.all())
-
     @patch('roleplay.views.messages')
     def test_user_gets_success_message_ok(self, mock_messages: MagicMock):
         self.client.force_login(self.user)
@@ -811,6 +805,18 @@ class TestCampaignLeaveView(TestCase):
             response.wsgi_request,
             'You have left the campaign.'
         )
+
+    def test_user_is_removed_from_campaign_ok(self):
+        self.client.force_login(self.user)
+        self.client.get(self.url)
+
+        self.assertNotIn(self.user, self.instance.users.all())
+
+    def test_user_is_removed_from_campaign_chat_ok(self):
+        self.client.force_login(self.user)
+        self.client.get(self.url)
+
+        self.assertNotIn(self.user, self.instance.chat.users.all())
 
 
 class TestCampaignListView(TestCase):


### PR DESCRIPTION
# Summary

Created logic for leaving the campaign and removing players (if logged user is game master).  
Also minor fixes related to displaying information to certain users.