### PR TITLE
feat(manage): read environment variables as files

### DIFF
--- a/common/utils/env.py
+++ b/common/utils/env.py
@@ -1,6 +1,7 @@
 import logging
+import os
 import pathlib
-from typing import Union
+from typing import Optional, Union
 
 from dotenv import dotenv_values, load_dotenv
 
@@ -34,6 +35,15 @@ def check_env_file(env_file: pathlib.Path) -> None:
 def load_env_file(env_file: Union[pathlib.Path, str]) -> bool:
     """
     Looks for the given .env file and sets up Environment Variables.
+
+    Parameters
+    ----------
+    env_file: :class:`Union[pathlib.Path, str]`
+        The dotenv file from which to load environment variables.
+
+    Returns
+    -------
+    Same value as :method:`dotenv.load_dotenv`.
     """
 
     if isinstance(env_file, str):
@@ -45,3 +55,34 @@ def load_env_file(env_file: Union[pathlib.Path, str]) -> bool:
 
     check_env_file(env_file)
     return load_dotenv(env_file, override=False, verbose=True, encoding='utf-8')
+
+
+def load_secrets(
+    secret_env_variables: list[str] = [
+        'SECRET_KEY', 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST', 'EMAIL_HOST', 'EMAIL_HOST_USER',
+        'EMAIL_HOST_PASSWORD', 'BOT_TOKEN',
+    ],
+    extra_env_variables: list[str] = [],
+    encoding: Optional[str] = None
+):
+    """
+    Looks for specific environment variables and check if they are files. If this is true it will read the file value
+    and set it as the environment variable.
+
+    Parameters
+    ----------
+    secret_env_variables: :class:`list[str]`
+        List of environment variables to iterate and check for files.
+    extra_env_variables: :class:`list[str]`
+        Any extra environment variable to check besides the given ones in `secret_env_variables`.
+    encoding: :class:`Optional[str]`
+        Encoding used for reading the files.
+    """
+
+    env_variables = secret_env_variables + extra_env_variables
+    for env_var in env_variables:
+        if env_var not in os.environ:
+            continue
+        file = pathlib.Path(os.environ[env_var])
+        if file.exists() and file.is_file():
+            os.environ[env_var] = file.read_text(encoding=encoding)

--- a/manage.py
+++ b/manage.py
@@ -4,13 +4,14 @@ import os
 import sys
 from pathlib import Path
 
-from common.utils.env import load_env_file
+from common.utils.env import load_env_file, load_secrets
 
 
 def main():
     BASE_DIR = Path(__file__).resolve().parent
     ENV_FILE = BASE_DIR / '.env'
     load_env_file(ENV_FILE)
+    load_secrets()
 
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'oilandrope.settings')
     try:

--- a/tests/common/utils/test_env.py
+++ b/tests/common/utils/test_env.py
@@ -1,10 +1,12 @@
+import os
 import pathlib
 import shutil
 import tempfile
+from unittest import mock
 
 from django.test import TestCase
 
-from common.utils.env import load_env_file
+from common.utils.env import load_env_file, load_secrets
 from common.utils.faker import create_faker
 
 fake = create_faker()
@@ -21,7 +23,7 @@ class TestEnv(TestCase):
         pathlib.Path(self.tmp_dir).rmdir()
 
     def test_load_env_with_all_expected_values_ok(self):
-        # NOTE: Windows doesn't have writting permission on %AppData%\Temp
+        # NOTE: Windows doesn't have writing permission on %AppData%\Temp
         env_file = self.tmp_file
         # We basically copy .env.example file
         shutil.copy('.env.example', str(env_file))
@@ -32,3 +34,59 @@ class TestEnv(TestCase):
         env_file = self.tmp_file
         with self.assertRaisesRegex(Warning, r'Some values are missing from .+'):
             load_env_file(str(env_file))
+
+    @mock.patch('common.utils.env.LOGGER')
+    def test_load_env_non_existent_file_raises_warning_ok(self, logger_mock: mock.MagicMock):
+        load_env_file(fake.file_name(extension='env'))
+
+        logger_mock.warning.assert_called_once_with(
+            'File \'%s\' couldn\'t be found. Using environment variables',
+            mock.ANY,
+        )
+
+    @mock.patch.dict('os.environ')
+    def test_load_secrets_all_are_files_ok(self):
+        secret_env_variables = [
+            'SECRET_KEY', 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST', 'EMAIL_HOST', 'EMAIL_HOST_USER',
+            'EMAIL_HOST_PASSWORD', 'BOT_TOKEN',
+        ]
+
+        for env_var in secret_env_variables:
+            secret_value: str = fake.pystr()
+            env_file = tempfile.NamedTemporaryFile(prefix=f'{env_var}-')
+            with open(env_file.name, 'w') as file_obj:
+                file_obj.write(secret_value)
+            os.environ[env_var] = env_file.name
+
+        load_secrets()
+
+        for env_var in secret_env_variables:
+            assert env_var in os.environ
+
+            assert not pathlib.Path(os.environ[env_var]).is_file()
+            assert isinstance(os.environ[env_var], str)
+
+    @mock.patch.dict('os.environ')
+    def test_load_secrets_only_certain_values_ok(self):
+        secret_key: str = fake.pystr()
+        secret_key_file = tempfile.NamedTemporaryFile(prefix='SECRET_KEY-')
+        with open(secret_key_file.name, 'w') as file_obj:
+            file_obj.write(secret_key)
+        os.environ['SECRET_KEY'] = secret_key_file.name
+
+        db_password: str = fake.pystr()
+        db_password_file = tempfile.NamedTemporaryFile(prefix='DB_PASSWORD-')
+        with open(db_password_file.name, 'w') as file_obj:
+            file_obj.write(db_password)
+        os.environ['DB_PASSWORD'] = db_password_file.name
+
+        load_secrets()
+
+        assert os.environ['SECRET_KEY'] == secret_key
+        assert os.environ['DB_PASSWORD'] == db_password
+
+    @mock.patch.dict('os.environ')
+    def test_load_secrets_with_non_existent_values_in_environment_variables_ok(self):
+        load_secrets(secret_env_variables=['RANDOM_VALUE'])
+
+        assert 'RANDOM_VALUE' not in os.environ


### PR DESCRIPTION
# Summary

As a result of searching a nice solution for reading files as environment variable (expected for Docker Swarm) we came up with checking some specific environment variables with sensitive data and reading them if they are files.

Added the capability to read some specific environment variables as files.